### PR TITLE
Added handling for 'online' Homie property

### DIFF
--- a/mqtt/client/mqpub-static.sh
+++ b/mqtt/client/mqpub-static.sh
@@ -52,3 +52,5 @@ then
         $PUBBIN -h $mqtthost $auth -t $topic/port$i/lock/\$settable -m "true" -r
     done
 fi
+
+$PUBBIN -h $mqtthost $auth -t $topic/\$online -m "true" -r

--- a/mqtt/client/mqsub.sh
+++ b/mqtt/client/mqsub.sh
@@ -15,7 +15,7 @@ echo 0 > /proc/led/freq
 
 log "MQTT listening..."
 $BIN_PATH/mosquitto_sub -I $clientID -h $mqtthost $auth -v -t $topic/+/+/set \
---will-topic $topic/$online --will-retain --will-qos 1 --will-payload 'false' \
+--will-topic $topic/\$online --will-retain --will-qos 1 --will-payload 'false' \
 | while read line; do
     rxtopic=`echo $line| cut -d" " -f1`
     inputVal=`echo $line| cut -d" " -f2`

--- a/mqtt/client/mqsub.sh
+++ b/mqtt/client/mqsub.sh
@@ -14,7 +14,9 @@ fi
 echo 0 > /proc/led/freq
 
 log "MQTT listening..."
-$BIN_PATH/mosquitto_sub -I $clientID -h $mqtthost $auth -v -t $topic/+/+/set | while read line; do
+$BIN_PATH/mosquitto_sub -I $clientID -h $mqtthost $auth -v -t $topic/+/+/set \
+--will-topic $topic/$online --will-retain --will-qos 1 --will-payload 'false' \
+| while read line; do
     rxtopic=`echo $line| cut -d" " -f1`
     inputVal=`echo $line| cut -d" " -f2`
     


### PR DESCRIPTION
According to the spec this is supposed to be the last property sent after the device is configured and other properties are published.  Added 'online = true' to mqpub-static.sh after other properties have been published.  Additionally, added a LWT message to the mqsub script so that when mosquitto_sub disconnects, 'online = false' is automatically published on the broker.  In the future, might want to consider sending 'online = true' every time port statuses are published, and might also want to consider sending 'online = false' in mqstop.sh

BTW @magcode your project is very useful, thank you for sharing it