### PR TITLE
Add message regarding SSH access

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,3 +8,11 @@ This project provides some tools for Ubiquiti Networks mPower devices.
 [bootstate](bootstate) Define which sockets are enabled during boot.
 
 [Thermostat](mqtt/thermostat) A simple thermostat script.
+
+# General notice
+
+Due to the ancient SSH daemon on the plugs modern SSH clients will not connect. You can pass the command
+line flag `-oKexAlgorithms=+diffie-hellman-group1-sha1` to allow your client to connect. An example would look
+like:
+
+`ssh -oKexAlgorithms=+diffie-hellman-group1-sha1 ubnt@192.168.2.20`


### PR DESCRIPTION
The ancient SSH daemon doesn't support modern ciphers wanted by current SSH clients. I added a quick note to the README about how to still connect.