### PR TITLE
Fix script and instructions to install nocontroller via SCP

### DIFF
--- a/nocontroller/install-nocontroller.sh
+++ b/nocontroller/install-nocontroller.sh
@@ -14,7 +14,7 @@ chmod 755 $scriptdir/syswrapper.sh
 startscript=$scriptdir/start.sh
 poststart=/etc/persistent/rc.poststart
 
-wget --no-check-certificate -q https://raw.githubusercontent.com/magcode/mpower-tools/master/nocontroller/start.sh -O $startscript
+mv ~/start.sh $startscript
 chmod 755 $startscript
 
 if [ ! -f $poststart ]; then
@@ -27,8 +27,9 @@ fi
 if grep -q "$startscript" "$poststart"; then
    echo "Found $poststart entry. File will not be changed"
 else
-   echo "Adding start command to $poststart"
-   echo -e "$startscript" >> $poststart
+   echo "Adding start command to $poststart as first line"
+   awk "NR==1{print; print \"$startscript\"} NR!=1" $poststart > /tmp/poststart
+   mv /tmp/poststart $poststart
 fi
  
 echo "Done!"

--- a/nocontroller/readme.md
+++ b/nocontroller/readme.md
@@ -8,11 +8,19 @@ Use at your own risk!
 Use only with Firmware `MF.v2.1.11`.
 
 # Installation
-Use a SSH client and connect to your mPower device.
+Download both install-nocontroller.sh and start.sh to your local device, and then copy them via
+SSH to your plug. An example for Linux or macOS would look like this:
+```
+cd /tmp
+wget https://raw.githubusercontent.com/magcode/mpower-tools/master/nocontroller/install-nocontroller.sh
+wget https://raw.githubusercontent.com/magcode/mpower-tools/master/nocontroller/start.sh
+scp -oKexAlgorithms=+diffie-hellman-group1-sha1 start.sh install-nocontroller.sh ubnt@MFI-IP:
+```
+Now we SSH into the plug and execute the install.
 Enter the following commands
 
 ```
-wget --no-check-certificate -q https://raw.githubusercontent.com/magcode/mpower-tools/master/nocontroller/install-nocontroller.sh -O /etc/persistent/install-nocontroller.sh;chmod 755 /etc/persistent/install-nocontroller.sh;/etc/persistent/install-nocontroller.sh
+sh ./install-nocontroller.sh
 save
 reboot
 ```


### PR DESCRIPTION
Since the ancient local wget cannot access HTTPS locations anymore I updated the readme and the scripts to install nocontroller via SCP instead.
Tested with a 2.1.11 3 port.

Thanks for the great script!